### PR TITLE
Hotfix/1.2.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,10 +15,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * org.apache.logging.log4j 2.11.0 -> 2.15.0 (addresses CVE-2021-44228)
 
-* com.vaadin 7.7.8 -> 7.7.28 (addresses CVE-2021-37714)
-
 **Deprecated**
-
 
 
 1.2.5 (2021-07-27)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,24 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-1.2.5 (20021-07-27)
+1.2.6 (2021-12-13)
+----------------------------------------------
+
+**Added**
+
+**Fixed**
+
+**Dependencies**
+
+* org.apache.logging.log4j 2.11.0 -> 2.15.0 (addresses CVE-2021-44228)
+
+* com.vaadin 7.7.8 -> 7.7.28 (addresses CVE-2021-37714)
+
+**Deprecated**
+
+
+
+1.2.5 (2021-07-27)
 ----------------------------------------------
 
 **Added**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Dependencies**
 
-* org.apache.logging.log4j 2.11.0 -> 2.15.0 (addresses CVE-2021-44228)
+* org.apache.logging.log4j:log4j-api: 2.11.0 -> 2.15.0 (addresses CVE-2021-44228)
+* org.apache.logging.log4j:log4j-core: 2.11.0 -> 2.15.0 (addresses CVE-2021-44228)
 
 **Deprecated**
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<version>3.1.3</version>
 	</parent>
 	<artifactId>ukt-diagnostics</artifactId>
-	<version>1.2.5</version>
+	<version>1.2.6</version>
 	<name>UKT diagnostics</name>
 
 	<properties>
@@ -112,6 +112,17 @@
 	</dependencyManagement>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.15.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.15.0</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>


### PR DESCRIPTION
1.2.6 (2021-12-13)
----------------------------------------------

**Added**

**Fixed**

**Dependencies**

* org.apache.logging.log4j 2.11.0 -> 2.15.0 (addresses CVE-2021-44228)

**Deprecated**