### PR TITLE
Bump version correctly to 1.2.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.2.7 (2021-12-13)
+----------------------------------------------
+
+**Added**
+
+**Fixed**
+
+* Version displayed in the portlet.
+
+**Dependencies**
+
+**Deprecated**
+
 1.2.6 (2021-12-13)
 ----------------------------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<version>3.1.3</version>
 	</parent>
 	<artifactId>ukt-diagnostics</artifactId>
-	<version>1.2.6</version>
+	<version>1.2.7</version>
 	<name>UKT diagnostics</name>
 
 	<properties>

--- a/src/main/java/life/qbic/AppInfo.java
+++ b/src/main/java/life/qbic/AppInfo.java
@@ -4,9 +4,9 @@ public class AppInfo {
 
     public static final String APPNAME = "ukt_diagnostic_portlet";
 
-    public static final String VERSION = "v1.2.5";
+    public static final String VERSION = "v1.2.7";
 
-    public static final String getAppInfo(){
+    public static String getAppInfo(){
         return String.format("[%s-%s]", APPNAME, VERSION);
     }
 


### PR DESCRIPTION
1.2.7 (2021-12-13)
----------------------------------------------

**Added**

**Fixed**

* Version displayed in the portlet.

**Dependencies**

**Deprecated**