### PR TITLE
Hotfix 1.2.8

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,6 +45,13 @@ jobs:
         java-version: 1.8
         settings-path: ${{ github.workspace }}
 
+    - name: Load local Maven repository cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.2.8 (2021-12-15)
+----------------------------------------------
+
+**Added**
+
+**Fixed**
+
+* Fix CVE-2021-45046
+
+**Dependencies**
+
+* org.apache.logging.log4j:log4j-api: 2.15.0 -> 2.16.0 (addresses CVE-2021-44228)
+* org.apache.logging.log4j:log4j-core: 2.15.0 -> 2.16.0 (addresses CVE-2021-44228)
+
+**Deprecated**
+
 1.2.7 (2021-12-13)
 ----------------------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,8 +15,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Dependencies**
 
-* org.apache.logging.log4j:log4j-api: 2.15.0 -> 2.16.0 (addresses CVE-2021-44228)
-* org.apache.logging.log4j:log4j-core: 2.15.0 -> 2.16.0 (addresses CVE-2021-44228)
+* org.apache.logging.log4j:log4j-api: 2.15.0 -> 2.16.0
+* org.apache.logging.log4j:log4j-core: 2.15.0 -> 2.16.0
 
 **Deprecated**
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<version>3.1.3</version>
 	</parent>
 	<artifactId>ukt-diagnostics</artifactId>
-	<version>1.2.7</version>
+	<version>1.2.8</version>
 	<name>UKT diagnostics</name>
 
 	<properties>
@@ -22,6 +22,7 @@
 		<liferay.version>6.2.5</liferay.version>
 		<liferay.maven.plugin.version>6.2.5</liferay.maven.plugin.version>
 		<jetty.plugin.version>9.4.35.v20201120</jetty.plugin.version>
+		<log4j.version>2.16.0</log4j.version>
 	</properties>
 	<packaging>war</packaging>
 	<!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
@@ -112,16 +113,6 @@
 	</dependencyManagement>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.15.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.15.0</version>
-		</dependency>
 
 		<dependency>
 			<groupId>org.powermock</groupId>

--- a/src/main/java/life/qbic/AppInfo.java
+++ b/src/main/java/life/qbic/AppInfo.java
@@ -4,7 +4,7 @@ public class AppInfo {
 
     public static final String APPNAME = "ukt_diagnostic_portlet";
 
-    public static final String VERSION = "v1.2.7";
+    public static final String VERSION = "v1.2.8";
 
     public static String getAppInfo(){
         return String.format("[%s-%s]", APPNAME, VERSION);


### PR DESCRIPTION
1.2.8 (2021-12-15)
----------------------------------------------

**Added**

**Fixed**

* Fix CVE-2021-45046

**Dependencies**

* org.apache.logging.log4j:log4j-api: 2.15.0 -> 2.16.0 
* org.apache.logging.log4j:log4j-core: 2.15.0 -> 2.16.0 

**Deprecated**

