### PR TITLE
Hotfix/1.2.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.2.10 (2022-01-04)
+----------------------------------------------
+
+**Added**
+
+**Fixed**
+
+* CVE-2021-44832
+
+**Dependencies**
+
+* ``org.apache.logging.log4j:log4j-core:2.17.0`` -> ``2.17.1``
+* ``org.apache.logging.log4j:log4j-api:2.17.0`` -> ``2.17.1``
+
 1.2.9 (2021-12-20)
 ----------------------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,11 +12,17 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 **Fixed**
 
 * CVE-2021-44832
+* CVE-2019-2692
 
 **Dependencies**
 
 * ``org.apache.logging.log4j:log4j-core:2.17.0`` -> ``2.17.1``
 * ``org.apache.logging.log4j:log4j-api:2.17.0`` -> ``2.17.1``
+* ``org.powermock.powermock-module-junit4:1.6.4`` -> ``2.0.9``
+* ``org.powermock.powermock-api-mockito:1.6.4`` -> ``1.7.4``
+* ``javax.portlet.portlet-api:2.0`` -> ``3.0.1``
+* ``javax.servlet.javax.servlet-api:3.0.1`` -> ``4.0.1``
+* ``mysql.mysql-connector-java:5.1.6`` -> ``8.0.27``
 
 1.2.9 (2021-12-20)
 ----------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -117,13 +117,13 @@
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
-			<version>1.6.4</version>
+			<version>2.0.9</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-api-mockito</artifactId>
-			<version>1.6.4</version>
+			<version>1.7.4</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -158,8 +158,7 @@
 		<dependency>
 			<groupId>javax.portlet</groupId>
 			<artifactId>portlet-api</artifactId>
-			<version>2.0</version>
-			<scope>provided</scope>
+			<version>3.0.1</version>
 		</dependency>
 
 		<dependency>
@@ -171,8 +170,7 @@
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
-			<version>3.0.1</version>
-			<scope>provided</scope>
+			<version>4.0.1</version>
 		</dependency>
 
 		<dependency>
@@ -206,7 +204,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.6</version>
+			<version>8.0.27</version>
 		</dependency>
 	</dependencies>
 <build>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<version>3.1.3</version>
 	</parent>
 	<artifactId>ukt-diagnostics</artifactId>
-	<version>1.2.9</version>
+	<version>1.2.10</version>
 	<name>UKT diagnostics</name>
 
 	<properties>
@@ -22,7 +22,7 @@
 		<liferay.version>6.2.5</liferay.version>
 		<liferay.maven.plugin.version>6.2.5</liferay.maven.plugin.version>
 		<jetty.plugin.version>9.4.35.v20201120</jetty.plugin.version>
-		<log4j.version>2.17.0</log4j.version>
+		<log4j.version>2.17.1</log4j.version>
 	</properties>
 	<packaging>war</packaging>
 	<!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->

--- a/src/main/java/life/qbic/AppInfo.java
+++ b/src/main/java/life/qbic/AppInfo.java
@@ -4,7 +4,7 @@ public class AppInfo {
 
     public static final String APPNAME = "ukt_diagnostic_portlet";
 
-    public static final String VERSION = "v1.2.9";
+    public static final String VERSION = "v1.2.10";
 
     public static String getAppInfo(){
         return String.format("[%s-%s]", APPNAME, VERSION);


### PR DESCRIPTION
1.2.10 (2022-01-04)
----------------------------------------------

**Added**

**Fixed**

* CVE-2021-44832
* CVE-2019-2692

**Dependencies**

* ``org.apache.logging.log4j:log4j-core:2.17.0`` -> ``2.17.1``
* ``org.apache.logging.log4j:log4j-api:2.17.0`` -> ``2.17.1``
* ``org.powermock.powermock-module-junit4:1.6.4`` -> ``2.0.9``
* ``org.powermock.powermock-api-mockito:1.6.4`` -> ``1.7.4``
* ``javax.portlet.portlet-api:2.0`` -> ``3.0.1``
* ``javax.servlet.javax.servlet-api:3.0.1`` -> ``4.0.1``
* ``mysql.mysql-connector-java:5.1.6`` -> ``8.0.27``